### PR TITLE
Remove duplicate call_id index from Call schema

### DIFF
--- a/server/models/Call.js
+++ b/server/models/Call.js
@@ -51,7 +51,6 @@ const callSchema = new mongoose.Schema({
 // Index for better query performance
 callSchema.index({ initiator: 1, createdAt: -1 });
 callSchema.index({ participants: 1, createdAt: -1 });
-callSchema.index({ call_id: 1 });
 
 const Call = mongoose.model('Call', callSchema);
 


### PR DESCRIPTION
## Purpose
Fix Mongoose warning about duplicate schema index on `call_id` field. The user was encountering a warning message indicating that the `call_id` field had duplicate index definitions, which occurs when an index is declared both through field options and schema.index() method.

## Code changes
- Removed the explicit `callSchema.index({ call_id: 1 })` declaration from the Call model
- This eliminates the duplicate index warning while maintaining the index functionality (likely defined elsewhere in the schema field definition)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/53aba85833b84612b8f98b10b3a5a2d5/mystic-studio)

👀 [Preview Link](https://53aba85833b84612b8f98b10b3a5a2d5-mystic-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>53aba85833b84612b8f98b10b3a5a2d5</projectId>-->
<!--<branchName>mystic-studio</branchName>-->