### PR TITLE
Fix post image container overflow covering action buttons

### DIFF
--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -154,7 +154,7 @@ const PostCard = ({post}) => {
 
         {/* Post Image/Media - Instagram Style */}
         {post.image_urls.length > 0 && (
-            <div className='relative aspect-square lg:aspect-auto lg:max-h-96 bg-gray-100'>
+            <div className='relative w-full aspect-square lg:aspect-auto lg:max-h-96 bg-gray-100 overflow-hidden'>
                 {post.image_urls.length === 1 ? (
                     <img
                         src={post.image_urls[0]}
@@ -162,13 +162,13 @@ const PostCard = ({post}) => {
                         alt=""
                     />
                 ) : (
-                    <div className='grid grid-cols-2 gap-0.5 h-full'>
+                    <div className='grid grid-cols-2 gap-0.5 w-full h-full'>
                         {post.image_urls.slice(0, 4).map((img, index) => (
-                            <div key={index} className="relative">
-                                <img 
-                                    src={img} 
-                                    className='w-full h-full object-cover' 
-                                    alt="" 
+                            <div key={index} className="relative overflow-hidden">
+                                <img
+                                    src={img}
+                                    className='w-full h-full object-cover'
+                                    alt=""
                                 />
                                 {index === 3 && post.image_urls.length > 4 && (
                                     <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">


### PR DESCRIPTION
## Purpose
Fix post image container overflow that was covering the likes, comments, share and other action buttons below the post images.

## Code changes
- Added `w-full` and `overflow-hidden` classes to the main post image container
- Added `w-full` class to the multi-image grid container  
- Added `overflow-hidden` class to individual image containers in the grid
- These changes ensure proper image containment and prevent visual overlap with post action elements

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c0ffe0cbf6b345ee937c253c895def8b/zenith-oasis)

👀 [Preview Link](https://c0ffe0cbf6b345ee937c253c895def8b-zenith-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c0ffe0cbf6b345ee937c253c895def8b</projectId>-->
<!--<branchName>zenith-oasis</branchName>-->